### PR TITLE
Update peerDependencies to support React 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "react-dom": "^17.0.2"
       },
       "peerDependencies": {
-        "react": "^16.9.0 || ^17.0.0"
+        "react": "^16.9.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "react": "^16.9.0 || ^17.0.0"
+    "react": "^16.9.0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.14.6",


### PR DESCRIPTION
This PR adds React 18 as a peerDependency, to fix an error when running `npm install use-chrome-storage` if React 18 is installed.