### PR TITLE
Attempt 2 typescript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,42 +1,99 @@
-/**
- * Hook which will use `chrome.storage.local` to persist state.
- *
- * @param {string} key - they key name in chrome's storage. Nested keys not supported
- * @param {*} [initialValue] - default value to use
- * @returns {[any, (value: any) => void, boolean, string]} - array of
- *      stateful `value`,
- *      function to update this `value`,
- *      `isPersistent` - will be `false` if error occurred during reading/writing chrome.storage,
- *      `error` - will contain error appeared in storage. if isPersistent is true will be empty string
- */
-export function useChromeStorageLocal(key: string, initialValue?: any): [any, (value: any) => void, boolean, string];
-/**
- * Hook which will use `chrome.storage.sync` to persist state.
- *
- * @param {string} key - they key name in chrome's storage. Nested keys not supported
- * @param {*} [initialValue] - default value to use
- * @returns {[any, (value: any) => void, boolean, string]} - array of
- *      stateful `value`,
- *      function to update this `value`,
- *      `isPersistent` - will be `false` if error occurred during reading/writing chrome.storage,
- *      `error` - will contain error appeared in storage. if isPersistent is true will be empty string
- */
-export function useChromeStorageSync(key: string, initialValue?: any): [any, (value: any) => void, boolean, string];
-/**
- * Use to create state with chrome.storage.local.
- * Useful if you want to reuse same state across components and/or context (like in popup, content script, background pages)
- *
- * @param {string} key - they key name in chrome's storage. Nested keys not supported
- * @param {*} [initialValue] - default value to use
- * @returns {function(): [any, (value: any) => void, boolean, string]}
- */
-export function createChromeStorageStateHookLocal(key: string, initialValue?: any): () => [any, (value: any) => void, boolean, string];
-/**
- * Use to create state with chrome.storage.sync.
- * Useful if you want to reuse same state across components and/or context (like in popup, content script, background pages)
- *
- * @param {string} key - they key name in chrome's storage. Nested keys not supported
- * @param {*} [initialValue] - default value to use
- * @returns {function(): [any, (value: any) => void, boolean, string]}
- */
-export function createChromeStorageStateHookSync(key: string, initialValue?: any): () => [any, (value: any) => void, boolean, string];
+export = useChromeStorage;
+export as namespace useChromeStorage;
+
+declare namespace useChromeStorage {
+  /**
+   * Hook which will use `chrome.storage.local` to persist state.
+   *
+   * @param {string} key - they key name in chrome's storage. Nested keys not supported
+   * @param {*} [initialValue] - default value to use
+   * @returns {[any, (value: any) => void, boolean, string]} - array of
+   *      stateful `value`,
+   *      function to update this `value`,
+   *      `isPersistent` - will be `false` if error occurred during reading/writing chrome.storage,
+   *      `error` - will contain error appeared in storage. if isPersistent is true will be empty string
+   */
+  function useChromeStorageLocal<S>(key: string, initialValue: S | (() => S)): [S, (value: S) => void, boolean, string];
+  // convenience overload when initialValue is omitted
+  /**
+   * Hook which will use `chrome.storage.local` to persist state.
+   *
+   * @param {string} key - they key name in chrome's storage. Nested keys not supported
+   * @param {*} [initialValue] - default value to use
+   * @returns {[any, (value: any) => void, boolean, string]} - array of
+   *      stateful `value`,
+   *      function to update this `value`,
+   *      `isPersistent` - will be `false` if error occurred during reading/writing chrome.storage,
+   *      `error` - will contain error appeared in storage. if isPersistent is true will be empty string
+   */
+  function useChromeStorageLocal<S = undefined>(key: string): [S | undefined, (value: S | undefined) => void, boolean, string];
+  
+  
+  /**
+   * Hook which will use `chrome.storage.sync` to persist state.
+   *
+   * @param {string} key - they key name in chrome's storage. Nested keys not supported
+   * @param {*} [initialValue] - default value to use
+   * @returns {[any, (value: any) => void, boolean, string]} - array of
+   *      stateful `value`,
+   *      function to update this `value`,
+   *      `isPersistent` - will be `false` if error occurred during reading/writing chrome.storage,
+   *      `error` - will contain error appeared in storage. if isPersistent is true will be empty string
+   */
+  function useChromeStorageSync<S>(key: string, initialValue: S | (() => S)): [S, (value: S) => void, boolean, string];
+  // convenience overload when initialValue is omitted
+  /**
+   * Hook which will use `chrome.storage.sync` to persist state.
+   *
+   * @param {string} key - they key name in chrome's storage. Nested keys not supported
+   * @param {*} [initialValue] - default value to use
+   * @returns {[any, (value: any) => void, boolean, string]} - array of
+   *      stateful `value`,
+   *      function to update this `value`,
+   *      `isPersistent` - will be `false` if error occurred during reading/writing chrome.storage,
+   *      `error` - will contain error appeared in storage. if isPersistent is true will be empty string
+   */
+  function useChromeStorageSync<S = undefined>(key: string): [S | undefined, (value: S | undefined) => void, boolean, string];
+  
+  
+  /**
+   * Use to create state with chrome.storage.local.
+   * Useful if you want to reuse same state across components and/or context (like in popup, content script, background pages)
+   *
+   * @param {string} key - they key name in chrome's storage. Nested keys not supported
+   * @param {*} [initialValue] - default value to use
+   * @returns {function(): [any, (value: any) => void, boolean, string]}
+   */
+  function createChromeStorageStateHookLocal<S>(key: string, initialValue: S | (() => S)): [S, (value: S) => void, boolean, string];
+  // convenience overload when initialValue is omitted
+  /**
+   * Use to create state with chrome.storage.local.
+   * Useful if you want to reuse same state across components and/or context (like in popup, content script, background pages)
+   *
+   * @param {string} key - they key name in chrome's storage. Nested keys not supported
+   * @param {*} [initialValue] - default value to use
+   * @returns {function(): [any, (value: any) => void, boolean, string]}
+   */
+  function createChromeStorageStateHookLocal<S = undefined>(key: string): [S | undefined, (value: S | undefined) => void, boolean, string];
+  
+    
+  /**
+   * Use to create state with chrome.storage.sync.
+   * Useful if you want to reuse same state across components and/or context (like in popup, content script, background pages)
+   *
+   * @param {string} key - they key name in chrome's storage. Nested keys not supported
+   * @param {*} [initialValue] - default value to use
+   * @returns {function(): [any, (value: any) => void, boolean, string]}
+   */
+  function createChromeStorageStateHookSync<S>(key: string, initialValue: S | (() => S)): [S, (value: S) => void, boolean, string];
+  // convenience overload when initialValue is omitted
+  /**
+   * Use to create state with chrome.storage.sync.
+   * Useful if you want to reuse same state across components and/or context (like in popup, content script, background pages)
+   *
+   * @param {string} key - they key name in chrome's storage. Nested keys not supported
+   * @param {*} [initialValue] - default value to use
+   * @returns {function(): [any, (value: any) => void, boolean, string]}
+   */
+  function createChromeStorageStateHookSync<S = undefined>(key: string): [S | undefined, (value: S | undefined) => void, boolean, string];
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+import { Dispatch, SetStateAction } from "react";
+
 export = useChromeStorage;
 export as namespace useChromeStorage;
 
@@ -13,7 +15,7 @@ declare namespace useChromeStorage {
    *      `isPersistent` - will be `false` if error occurred during reading/writing chrome.storage,
    *      `error` - will contain error appeared in storage. if isPersistent is true will be empty string
    */
-  function useChromeStorageLocal<S>(key: string, initialValue: S | (() => S)): [S, (value: S) => void, boolean, string];
+  function useChromeStorageLocal<S>(key: string, initialValue: S | (() => S)): [S, Dispatch<SetStateAction<S>>, boolean, string];
   // convenience overload when initialValue is omitted
   /**
    * Hook which will use `chrome.storage.local` to persist state.
@@ -26,7 +28,7 @@ declare namespace useChromeStorage {
    *      `isPersistent` - will be `false` if error occurred during reading/writing chrome.storage,
    *      `error` - will contain error appeared in storage. if isPersistent is true will be empty string
    */
-  function useChromeStorageLocal<S = undefined>(key: string): [S | undefined, (value: S | undefined) => void, boolean, string];
+  function useChromeStorageLocal<S = undefined>(key: string): [S | undefined, Dispatch<SetStateAction<S | undefined>>, boolean, string];
   
   
   /**
@@ -40,7 +42,7 @@ declare namespace useChromeStorage {
    *      `isPersistent` - will be `false` if error occurred during reading/writing chrome.storage,
    *      `error` - will contain error appeared in storage. if isPersistent is true will be empty string
    */
-  function useChromeStorageSync<S>(key: string, initialValue: S | (() => S)): [S, (value: S) => void, boolean, string];
+  function useChromeStorageSync<S>(key: string, initialValue: S | (() => S)): [S, Dispatch<SetStateAction<S>>, boolean, string];
   // convenience overload when initialValue is omitted
   /**
    * Hook which will use `chrome.storage.sync` to persist state.
@@ -53,7 +55,7 @@ declare namespace useChromeStorage {
    *      `isPersistent` - will be `false` if error occurred during reading/writing chrome.storage,
    *      `error` - will contain error appeared in storage. if isPersistent is true will be empty string
    */
-  function useChromeStorageSync<S = undefined>(key: string): [S | undefined, (value: S | undefined) => void, boolean, string];
+  function useChromeStorageSync<S = undefined>(key: string): [S | undefined, Dispatch<SetStateAction<S | undefined>>, boolean, string];
   
   
   /**
@@ -64,7 +66,7 @@ declare namespace useChromeStorage {
    * @param {*} [initialValue] - default value to use
    * @returns {function(): [any, (value: any) => void, boolean, string]}
    */
-  function createChromeStorageStateHookLocal<S>(key: string, initialValue: S | (() => S)): [S, (value: S) => void, boolean, string];
+  function createChromeStorageStateHookLocal<S>(key: string, initialValue: S | (() => S)): [S, Dispatch<SetStateAction<S>>, boolean, string];
   // convenience overload when initialValue is omitted
   /**
    * Use to create state with chrome.storage.local.
@@ -74,7 +76,7 @@ declare namespace useChromeStorage {
    * @param {*} [initialValue] - default value to use
    * @returns {function(): [any, (value: any) => void, boolean, string]}
    */
-  function createChromeStorageStateHookLocal<S = undefined>(key: string): [S | undefined, (value: S | undefined) => void, boolean, string];
+  function createChromeStorageStateHookLocal<S = undefined>(key: string): [S | undefined, Dispatch<SetStateAction<S | undefined>>, boolean, string];
   
     
   /**
@@ -85,7 +87,7 @@ declare namespace useChromeStorage {
    * @param {*} [initialValue] - default value to use
    * @returns {function(): [any, (value: any) => void, boolean, string]}
    */
-  function createChromeStorageStateHookSync<S>(key: string, initialValue: S | (() => S)): [S, (value: S) => void, boolean, string];
+  function createChromeStorageStateHookSync<S>(key: string, initialValue: S | (() => S)): [S, Dispatch<SetStateAction<S>>, boolean, string];
   // convenience overload when initialValue is omitted
   /**
    * Use to create state with chrome.storage.sync.
@@ -95,5 +97,5 @@ declare namespace useChromeStorage {
    * @param {*} [initialValue] - default value to use
    * @returns {function(): [any, (value: any) => void, boolean, string]}
    */
-  function createChromeStorageStateHookSync<S = undefined>(key: string): [S | undefined, (value: S | undefined) => void, boolean, string];
+  function createChromeStorageStateHookSync<S = undefined>(key: string): [S | undefined, Dispatch<SetStateAction<S | undefined>>, boolean, string];
 }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "umd:main": "dist/index.umd.js",
   "typings": "index.d.ts",
   "scripts": {
-    "build": "microbundle",
-    "dev": "microbundle watch",
+    "build": "microbundle --generateTypes false",
+    "dev": "microbundle watch --generateTypes false",
     "release": "npm run build && np --no-yarn --no-cleanup",
     "preview": "npm run build && np --no-yarn --no-cleanup --preview",
     "test": "jest"


### PR DESCRIPTION
Second attempt at #276
This time microbundle is ran using --generateTypes false to prevent it from overwriting the types based on the JSDocs.

Also cleaned up the d.ts file with namespace declaration.