### PR TITLE
fix: Typescript on hook functions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,7 @@ declare namespace useChromeStorage {
    *      `isPersistent` - will be `false` if error occurred during reading/writing chrome.storage,
    *      `error` - will contain error appeared in storage. if isPersistent is true will be empty string
    */
-  function useChromeStorageLocal<S>(key: string, initialValue: S | (() => S)): () => [S, Dispatch<SetStateAction<S>>, boolean, string];
+  function useChromeStorageLocal<S>(key: string, initialValue: S | (() => S)): [S, Dispatch<SetStateAction<S>>, boolean, string];
   // convenience overload when initialValue is omitted
   /**
    * Hook which will use `chrome.storage.local` to persist state.
@@ -28,7 +28,7 @@ declare namespace useChromeStorage {
    *      `isPersistent` - will be `false` if error occurred during reading/writing chrome.storage,
    *      `error` - will contain error appeared in storage. if isPersistent is true will be empty string
    */
-  function useChromeStorageLocal<S = undefined>(key: string): () => [S | undefined, Dispatch<SetStateAction<S | undefined>>, boolean, string];
+  function useChromeStorageLocal<S = undefined>(key: string): [S | undefined, Dispatch<SetStateAction<S | undefined>>, boolean, string];
 
 
   /**
@@ -42,7 +42,7 @@ declare namespace useChromeStorage {
    *      `isPersistent` - will be `false` if error occurred during reading/writing chrome.storage,
    *      `error` - will contain error appeared in storage. if isPersistent is true will be empty string
    */
-  function useChromeStorageSync<S>(key: string, initialValue: S | (() => S)): () => [S, Dispatch<SetStateAction<S>>, boolean, string];
+  function useChromeStorageSync<S>(key: string, initialValue: S | (() => S)): [S, Dispatch<SetStateAction<S>>, boolean, string];
   // convenience overload when initialValue is omitted
   /**
    * Hook which will use `chrome.storage.sync` to persist state.
@@ -55,7 +55,7 @@ declare namespace useChromeStorage {
    *      `isPersistent` - will be `false` if error occurred during reading/writing chrome.storage,
    *      `error` - will contain error appeared in storage. if isPersistent is true will be empty string
    */
-  function useChromeStorageSync<S = undefined>(key: string): () => [S | undefined, Dispatch<SetStateAction<S | undefined>>, boolean, string];
+  function useChromeStorageSync<S = undefined>(key: string): [S | undefined, Dispatch<SetStateAction<S | undefined>>, boolean, string];
 
 
   /**
@@ -66,7 +66,7 @@ declare namespace useChromeStorage {
    * @param {*} [initialValue] - default value to use
    * @returns {function(): [any, (value: any) => void, boolean, string]}
    */
-  function createChromeStorageStateHookLocal<S>(key: string, initialValue: S | (() => S)): () => [S, Dispatch<SetStateAction<S>>, boolean, string];
+  function createChromeStorageStateHookLocal<S>(key: string, initialValue: S | (() => S)): [S, Dispatch<SetStateAction<S>>, boolean, string];
   // convenience overload when initialValue is omitted
   /**
    * Use to create state with chrome.storage.local.
@@ -76,7 +76,7 @@ declare namespace useChromeStorage {
    * @param {*} [initialValue] - default value to use
    * @returns {function(): [any, (value: any) => void, boolean, string]}
    */
-  function createChromeStorageStateHookLocal<S = undefined>(key: string): () => [S | undefined, Dispatch<SetStateAction<S | undefined>>, boolean, string];
+  function createChromeStorageStateHookLocal<S = undefined>(key: string): [S | undefined, Dispatch<SetStateAction<S | undefined>>, boolean, string];
 
 
   /**
@@ -87,7 +87,7 @@ declare namespace useChromeStorage {
    * @param {*} [initialValue] - default value to use
    * @returns {function(): [any, (value: any) => void, boolean, string]}
    */
-  function createChromeStorageStateHookSync<S>(key: string, initialValue: S | (() => S)): () => [S, Dispatch<SetStateAction<S>>, boolean, string];
+  function createChromeStorageStateHookSync<S>(key: string, initialValue: S | (() => S)): [S, Dispatch<SetStateAction<S>>, boolean, string];
   // convenience overload when initialValue is omitted
   /**
    * Use to create state with chrome.storage.sync.
@@ -97,5 +97,5 @@ declare namespace useChromeStorage {
    * @param {*} [initialValue] - default value to use
    * @returns {function(): [any, (value: any) => void, boolean, string]}
    */
-  function createChromeStorageStateHookSync<S = undefined>(key: string): () => [S | undefined, Dispatch<SetStateAction<S | undefined>>, boolean, string];
+  function createChromeStorageStateHookSync<S = undefined>(key: string): [S | undefined, Dispatch<SetStateAction<S | undefined>>, boolean, string];
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -66,7 +66,7 @@ declare namespace useChromeStorage {
    * @param {*} [initialValue] - default value to use
    * @returns {function(): [any, (value: any) => void, boolean, string]}
    */
-  function createChromeStorageStateHookLocal<S>(key: string, initialValue: S | (() => S)): [S, Dispatch<SetStateAction<S>>, boolean, string];
+  function createChromeStorageStateHookLocal<S>(key: string, initialValue: S | (() => S)): () => [S, Dispatch<SetStateAction<S>>, boolean, string];
   // convenience overload when initialValue is omitted
   /**
    * Use to create state with chrome.storage.local.
@@ -76,7 +76,7 @@ declare namespace useChromeStorage {
    * @param {*} [initialValue] - default value to use
    * @returns {function(): [any, (value: any) => void, boolean, string]}
    */
-  function createChromeStorageStateHookLocal<S = undefined>(key: string): [S | undefined, Dispatch<SetStateAction<S | undefined>>, boolean, string];
+  function createChromeStorageStateHookLocal<S = undefined>(key: string): () => [S | undefined, Dispatch<SetStateAction<S | undefined>>, boolean, string];
 
 
   /**
@@ -87,7 +87,7 @@ declare namespace useChromeStorage {
    * @param {*} [initialValue] - default value to use
    * @returns {function(): [any, (value: any) => void, boolean, string]}
    */
-  function createChromeStorageStateHookSync<S>(key: string, initialValue: S | (() => S)): [S, Dispatch<SetStateAction<S>>, boolean, string];
+  function createChromeStorageStateHookSync<S>(key: string, initialValue: S | (() => S)): () => [S, Dispatch<SetStateAction<S>>, boolean, string];
   // convenience overload when initialValue is omitted
   /**
    * Use to create state with chrome.storage.sync.
@@ -97,5 +97,5 @@ declare namespace useChromeStorage {
    * @param {*} [initialValue] - default value to use
    * @returns {function(): [any, (value: any) => void, boolean, string]}
    */
-  function createChromeStorageStateHookSync<S = undefined>(key: string): [S | undefined, Dispatch<SetStateAction<S | undefined>>, boolean, string];
+  function createChromeStorageStateHookSync<S = undefined>(key: string): () => [S | undefined, Dispatch<SetStateAction<S | undefined>>, boolean, string];
 }


### PR DESCRIPTION
This PR fixes types created in Typescript for hooks. The return must be the function's return and not the function itself.

---

Fixes https://github.com/onikienko/use-chrome-storage/issues/342