### PR TITLE
fix(session): added types for session storage hook

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -63,6 +63,35 @@ declare namespace useChromeStorage {
     function useChromeStorageSync<S = undefined>(key: string): [S | undefined, Dispatch<SetStateAction<S | undefined>>, boolean, string, boolean];
 
 
+  /**
+   * Hook which will use `chrome.storage.session` to persist state.
+   *
+   * @param {string} key - they key name in chrome's storage. Nested keys not supported
+   * @param {*} [initialValue] - default value to use
+   * @returns {[any, (value: any) => void, boolean, string, boolean]} - array of
+   *      stateful `value`,
+   *      function to update this `value`,
+   *      `isPersistent` - will be `false` if error occurred during reading/writing chrome.storage,
+   *      `error` - will contain error appeared in storage. if isPersistent is true will be empty string
+   *      `isInitialStateResolved` - will set to `true` once `initialValue` will be replaced with stored in chrome.storage
+   */
+  function useChromeStorageSession<S>(key: string, initialValue: S | (() => S)): [S, Dispatch<SetStateAction<S>>, boolean, string, boolean];
+  // convenience overload when initialValue is omitted
+    /**
+     * Hook which will use `chrome.storage.session` to persist state.
+     *
+     * @param {string} key - they key name in chrome's storage. Nested keys not supported
+     * @param {*} [initialValue] - default value to use
+     * @returns {[any, (value: any) => void, boolean, string, boolean]} - array of
+     *      stateful `value`,
+     *      function to update this `value`,
+     *      `isPersistent` - will be `false` if error occurred during reading/writing chrome.storage,
+     *      `error` - will contain error appeared in storage. if isPersistent is true will be empty string
+     *      `isInitialStateResolved` - will set to `true` once `initialValue` will be replaced with stored in chrome.storage
+     */
+    function useChromeStorageSession<S = undefined>(key: string): [S | undefined, Dispatch<SetStateAction<S | undefined>>, boolean, string, boolean];
+
+
     /**
      * Use to create state with chrome.storage.local.
      * Useful if you want to reuse same state across components and/or context (like in popup, content script, background pages)
@@ -103,4 +132,25 @@ declare namespace useChromeStorage {
      * @returns {function(): [any, (value: any) => void, boolean, string, boolean]}
      */
     function createChromeStorageStateHookSync<S = undefined>(key: string): () => [S | undefined, Dispatch<SetStateAction<S | undefined>>, boolean, string, boolean];
+
+
+    /**
+     * Use to create state with chrome.storage.session.
+     * Useful if you want to reuse same state across components and/or context (like in popup, content script, background pages)
+     *
+     * @param {string} key - they key name in chrome's storage. Nested keys not supported
+     * @param {*} [initialValue] - default value to use
+     * @returns {function(): [any, (value: any) => void, boolean, string, boolean]}
+     */
+    function createChromeStorageStateHookSession<S>(key: string, initialValue: S | (() => S)): () => [S, Dispatch<SetStateAction<S>>, boolean, string, boolean];
+  // convenience overload when initialValue is omitted
+    /**
+     * Use to create state with chrome.storage.session.
+     * Useful if you want to reuse same state across components and/or context (like in popup, content script, background pages)
+     *
+     * @param {string} key - they key name in chrome's storage. Nested keys not supported
+     * @param {*} [initialValue] - default value to use
+     * @returns {function(): [any, (value: any) => void, boolean, string, boolean]}
+     */
+    function createChromeStorageStateHookSession<S = undefined>(key: string): () => [S | undefined, Dispatch<SetStateAction<S | undefined>>, boolean, string, boolean];
 }


### PR DESCRIPTION
Getting an error when using with typescript project while importing `useChromeStorageSession`
error message: `"use-chrome-storage" has no exported member named 'useChromeStorageSession'`

(it works fine if we disable typescript, but then we don't get type safety)