### PR TITLE
Restore the state to the initial value when no new value is set in a storage change event

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,15 @@ but this behavior can be changed by calling `chrome.storage.session.setAccessLev
 (call it from background script).
 https://developer.chrome.com/docs/extensions/reference/storage/#method-StorageArea-setAccessLevel
 
+### Clearing or removing storage items
+
+Suppose you want to reset all your stored items back to their initial values. 
+
+You could, for example, use `chrome.storage.local.clear()` (or their 'session', 'sync' counterparts) to clear the entire storage.  
+Alternatively, you can use `chrome.storage.local.remove(key)` to remove a specific storage item.
+
+This will trigger a sync event in your `useChromeStorage[Local|Session|Sync]` hooks, setting them back to their _initial value_.
+
 ## API
 
 ### useChromeStorageLocal(key, initialValue?)
@@ -194,7 +203,7 @@ State will be persisted in `chrome.storage.local` (and updated from `chrome.stor
 contexts). If you want to use this hook in more than one place, use `createChromeStorageStateHookLocal`.
 
 - `key: string` - The key used in `chrome.storage.local`
-- `initialValue: any = undefined` - value which will be used if `chrome.storage.local` has no stored value yet
+- `initialValue: any = undefined` - value which will be used if `chrome.storage.local` has no stored value yet or when a stored item is removed (unset)
 
 #### Returns
 

--- a/src/useChromeStorage.js
+++ b/src/useChromeStorage.js
@@ -53,8 +53,15 @@ export default function useChromeStorage(key, initialValue, storageArea) {
     useEffect(() => {
         const onChange = (changes, areaName) => {
             if (areaName === STORAGE_AREA && key in changes) {
-                setState(changes[key].newValue);
-                setIsPersistent(true);
+                const change = changes[key]; 
+                const isValueStored = 'newValue' in change;
+                // only set the new value if it's actually stored (otherwise it'll just set undefined)
+                if (isValueStored) {
+                    setState(change.newValue);
+                } else {
+                    setState(INITIAL_VALUE);
+                }
+                setIsPersistent(isValueStored);
                 setError('');
             }
         };


### PR DESCRIPTION
Resetting the storage or removing an item used to reset it's state value to 'undefined', regardless of it's initial value.
This PR fixes that.
See this issue for the original context; https://github.com/eamonwoortman/use-chrome-storage/issues/1